### PR TITLE
Update github-tag-action to 1.39.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.CICD_TOKEN }}
 
     - name: Tag branch
-      uses: anothrNick/github-tag-action@1.26.0
+      uses: anothrNick/github-tag-action@1.39.0
       env:
         GITHUB_TOKEN: ${{ secrets.CICD_TOKEN }}
         CUSTOM_TAG: 'v${{ steps.version.outputs.chart }}'


### PR DESCRIPTION
github-tag-action 1.26.0 has bug: detected dubious ownership in repository at '/github/workspace'.
Update to 1.39.0 solve it.

Signed-off-by: Jiri Marek <jiri.marek@dnation.cloud>