### PR TITLE
Add missing replica-label to workload cluster

### DIFF
--- a/multicluster-config/workload-values-openshift.yaml
+++ b/multicluster-config/workload-values-openshift.yaml
@@ -21,6 +21,8 @@ thanos:
   queryFrontend:
     enabled: false
   query:
+    replicaLabel:
+      - prometheus_replica  
     dnsDiscovery:
       sidecarsService: kube-prometheus-thanos-discovery
       sidecarsNamespace: "{{ .Release.Namespace }}"

--- a/multicluster-config/workload-values.yaml
+++ b/multicluster-config/workload-values.yaml
@@ -15,6 +15,8 @@ thanos:
   queryFrontend:
     enabled: false
   query:
+    replicaLabel:
+      - prometheus_replica
     dnsDiscovery:
       sidecarsService: kube-prometheus-thanos-discovery
       sidecarsNamespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
This parameter in query is needed to ensure data deduplication from workload clusters.