### PR TITLE
Fix seccomp-profiles for openshift

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 name: dnation-kubernetes-monitoring-stack
-version: 3.4.2
+version: 3.4.3
 appVersion: 2.6.2  # dnation-kubernetes-monitoring
 description: An umbrella helm chart for Kubernetes monitoring based on kube-prometheus-stack, thanos, loki, loki-distributed, promtail and dnation-kubernetes-monitoring.
 keywords:

--- a/chart/templates/openshift/scc.yaml
+++ b/chart/templates/openshift/scc.yaml
@@ -14,6 +14,8 @@ allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities: []
 defaultAddCapabilities: null
+seccompProfiles:
+- runtime/default 
 fsGroup:
   type: RunAsAny
 groups:


### PR DESCRIPTION
This commit fixes a  problem with seccomp profiles for openshift after these profiles were introduced in kube-prometheus-stack version 46.3, see https://github.com/prometheus-community/helm-charts/pull/3201