### PR TITLE
Fix when extraflags for thanos components were overridden

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@
 
 apiVersion: v2
 name: dnation-kubernetes-monitoring-stack
-version: 3.5.0
+version: 3.5.1
 appVersion: 2.7.0  # dnation-kubernetes-monitoring
 description: An umbrella helm chart for Kubernetes monitoring based on kube-prometheus-stack, thanos, loki, loki-distributed, promtail and dnation-kubernetes-monitoring.
 keywords:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -93,16 +93,6 @@ thanos:
   enabled: true
   queryFrontend:
     enabled: false
-    extraFlags:
-    - --query-range.split-interval=12h
-    - --query-frontend.log-queries-longer-than=10s
-    - --query-frontend.compress-responses
-    - |-
-      --query-range.response-cache-config="config":
-        "max_size": "500MB"
-        "max_size_items": 0
-        "validity": 0s
-      "type": "in-memory"
   query:
     extraFlags:
     - --query.auto-downsampling
@@ -113,12 +103,6 @@ thanos:
     enabled: false
   compactor:
     enabled: false
-    retentionResolutionRaw: 2d
-    retentionResolution5m: 10d
-    retentionResolution1h: 15d
-    extraFlags:
-    - --compact.concurrency=3
-    - --downsample.concurrency=3
   storegateway:
     enabled: false
   ruler:

--- a/multicluster-config/observer-values.yaml
+++ b/multicluster-config/observer-values.yaml
@@ -52,7 +52,19 @@ thanos:
   existingObjstoreSecret: thanos-objstore-config
   queryFrontend:
     enabled: true
+    extraFlags:
+    - --query-range.split-interval=12h
+    - --query-frontend.log-queries-longer-than=10s
+    - --query-frontend.compress-responses
+    - |-
+      --query-range.response-cache-config="config":
+        "max_size": "500MB"
+        "max_size_items": 0
+        "validity": 0s
+      "type": "in-memory"    
   query:
+    extraFlags:
+    - --query.auto-downsampling  
     replicaLabel:
       - prometheus_replica
     dnsDiscovery:
@@ -100,6 +112,12 @@ thanos:
     enabled: true
   compactor:
     enabled: true
+    retentionResolutionRaw: 2d
+    retentionResolution5m: 10d
+    retentionResolution1h: 15d
+    extraFlags:
+    - --compact.concurrency=3
+    - --downsample.concurrency=3    
   storegateway:
     enabled: true
   ruler:


### PR DESCRIPTION
This commit fixes the scenario when settings for thanos components, which are set via extra flags in `values.yaml` was overridden by values in a multicluster-config folder.